### PR TITLE
support single playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ _Note: I do not plan on making this end-user friendly with a GUI._
 
 Script Options
 ----
-**-e / --email**
+**-a / --androidID**
 
-_Required._ Specifies the email address to login with. 
+_Required._ Specifies the android id to login with. 
 
 
-**-p / --password**
+**-t / --token**
 
-_Required._ Specifies the password to login with.
+_Required._ Specifies the token to login with.
 
 
 **-i / --input**
@@ -49,6 +49,10 @@ _Optional._ The names to create the shuffled playlists with. Multiple playlists 
 **--overwrite**
 
 _Optional._ Defaults to false. If any of the output playlists already exists, then they this flag specifies if they will be overwritten or if the script will stop. No value needs to be specified with this option: `--overwrite`
+
+**--singlePlaylist**
+
+_Optional._ Defaults to false. This flag specifies that only one playlist will be created`--singlePlaylist`
 
 Attribution
 ----

--- a/src/args.ts
+++ b/src/args.ts
@@ -8,6 +8,7 @@ class Args {
 	androidId: string;
 	token: string;
 	overwrite: boolean;
+	singlePlaylist: boolean;
 	input: string[];
 	output: string[];
 
@@ -18,14 +19,16 @@ class Args {
 			.option({ name: "input", short: "i", type: "list,string" })
 			.option({ name: "output", short: "o", type: "list,string" })
 			.option({ name: "overwrite", type: "boolean" })
-			.option({ name: "maxTracksPerPlaylist", type: "number" })
+			.option({ name: "maxTracksPerPlaylist", short: "m", type: "number" })
+			.option({ name: "singlePlaylist", type: "boolean" })
 			.run();
 		this.androidId = args.options["androidId"];
 		this.token = args.options["token"];
 		this.input = args.options["input"];
 		this.output = args.options["output"];
 		this.overwrite = args.options["overwrite"] === true;
-		this.maxTracksPerPlaylist = args.options["maxTracksPerPlaylist"];
+		this.maxTracksPerPlaylist = parseInt(args.options["maxTracksPerPlaylist"]) || 0;
+		this.singlePlaylist = args.options["singlePlaylist"] === true;
 		this.validate();
 	}
 

--- a/src/shuffler.ts
+++ b/src/shuffler.ts
@@ -11,7 +11,13 @@ export default class Shuffler {
 			this.cache.getPlaylistsByName(Args.input).then((playlists) => {
 				this.cache.populatePlaylistTracks(playlists).then((newPlaylists) => {
 					const tracks = this.shuffleTracks(this.getUniqueTracks(newPlaylists));
-					const playlistsNeeded = Math.ceil(tracks.length / Args.maxTracksPerPlaylist);
+					if (Args.singlePlaylist) {
+						var playlists = 1;
+					}
+					else {
+						var playlists = Math.ceil(tracks.length / Args.maxTracksPerPlaylist);
+					}
+					const playlistsNeeded = playlists
 					this.getOutputPlaylistNames(playlistsNeeded).then((playlistNames) => {
 						const playlistPartitions = this.partitionTracks(tracks, playlistsNeeded);
 						let partitionIndex = 0;


### PR DESCRIPTION
fix the maxTracksPerPlaylist function
add support for “m” short for maxTracksPerPlaylist

This is actually good for Android Wear Playlists. Current Devices have 4gb of storage which doesn't allow for you do keep a sizable playlist. Instead of trying to sync one "mega" playlist - this shuffle takes the one playlist and shuffles down into a more manageable android wear friendly playlist. e.g. 150 tracks. Once you get tired of the shuffle you just reshuffle your "mega" playlist again a new mix.